### PR TITLE
Add new types of job parameter

### DIFF
--- a/templates/run.yaml.j2
+++ b/templates/run.yaml.j2
@@ -77,6 +77,17 @@
           default: {{ value }}
 {% endfor %}
 
+{% if job_custom_parameters is defined %}
+{% for parameter in job_custom_parameters %}
+- parameter:
+    name: {{ project }}-{{ parameter.name }}
+    parameters:
+      - {{ parameter.type }}:
+          name: {{ parameter.name }}
+          default: {{ parameter.default }}
+{% endfor %}
+{% endif %}
+
 - {{ project }}-run-containers: &{{ project }}-run-containers
     name: '{{ project }}-run-containers'
     <<: *{{ project }}-containers
@@ -111,6 +122,19 @@
       - shell: |
           set +x
           [ ! -z "$WORKSPACE" ] && {{sudo1 }}rm -rf $WORKSPACE/results || true
+{% if job_custom_parameters is defined %}
+{% for parameter in job_custom_parameters %}
+{% if parameter.type == "text" %}
+{% if parameter.dest is defined %}
+{% if use_kubernetes and not use_slave %}
+          echo "${{ parameter.name }}" > $WORKSPACE/{{ parameter.dest }}
+{% else %}
+          echo "${{ parameter.name }}" > {{ jenkins_workspace }}/$JOB_NAME/{{ parameter.dest }}
+{% endif %}
+{% endif %}
+{% endif %}
+{% endfor %}
+{% endif %}
           if [ "{repo}" = "_" ]; then
             image={container}:{tag}
           elif [ "{port}" = "None" ]; then
@@ -251,6 +275,12 @@
       - {{ project }}-{{ key }}:
           {{ key }}: {{ value }}
 {% endfor %}
+{% if job_custom_parameters is defined %}
+{% for parameter in job_custom_parameters %}
+      - {{ project }}-{{ parameter.name }}:
+          {{ parameter.name }}: {{ parameter.default }}
+{% endfor %}
+{% endif %}
     builders:
 {% if use_artifacts == true %}
 {% for volume in docker_args.volumes %}
@@ -352,6 +382,12 @@
       - {{ project }}-{{ key }}:
           {{ key }}: {{ value }}
 {% endfor %}
+{% if job_custom_parameters is defined %}
+{% for parameter in job_custom_parameters %}
+      - {{ project }}-{{ parameter.name }}:
+          {{ parameter.name }}: {{ parameter.default }}
+{% endfor %}
+{% endif %}
     builders:
 {% if use_artifacts == true %}
 {% for volume in docker_args.volumes %}
@@ -400,6 +436,12 @@
       - {{ project }}-{{ key }}:
           {{ key }}: {{ value }}
 {% endfor %}
+{% if job_custom_parameters is defined %}
+{% for parameter in job_custom_parameters %}
+      - {{ project }}-{{ parameter.name }}:
+          {{ parameter.name }}: {{ parameter.default }}
+{% endfor %}
+{% endif %}
     properties:
       - build-blocker:
           use-build-blocker: true


### PR DESCRIPTION
Add the possibility to define job paremeter with another type than string ones.
Example: 
- text job parameter which coupled with volume can permit to override some files content directly using job parameter. Possibles use cases : custom behave feature file, ansible vars file ...