### PR TITLE
added publish_ports docker parameter in Jenkins job

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -25,6 +25,7 @@ docker_tags:
 docker_args:
   env: {}
   volumes: []
+  published_ports: []
 suites:
   - container: xtesting
     # privileged: false

--- a/templates/run.yaml.j2
+++ b/templates/run.yaml.j2
@@ -123,6 +123,16 @@
           name: {{ key }}
           default: {{ value }}
 {% endfor %}
+{% for port in docker_args.published_ports %}
+
+- parameter:
+    name: {{ project }}-published_ports-{{ port }}
+    parameters:
+      - string:
+        name: published_ports-{{ port }}
+        default: {{ port }}
+
+{% endfor %}
 
 - {{ project }}-run-containers: &{{ project }}-run-containers
     name: '{{ project }}-run-containers'
@@ -132,6 +142,7 @@
     volumes: '{volumes}'
     env: '{env}'
     network: '{network}'
+    published_ports: '{published_ports}'
 {% for key, value in docker_tags.0.items() |list %}
 {% for key, value in value.items() |list %}
 {% if not (key=='branch' or key=='slave' or key=='node' or key=='dependency') %}
@@ -169,6 +180,11 @@
             for i in $(eval echo {env} | tr -d '[]' |sed "s/, / /g" ); \
               do env="-e $i $env"; done
           fi
+          published_ports=;
+          if [ "{published_ports}" != "None" ]; then
+            for i in $(echo {published_ports} | tr -d '[]' |sed "s/, / /g" ); \
+              do published_ports="-p $i $published_ports"; done
+          fi
           [ ! -z "$WORKSPACE" ] && {{sudo1 }}rm -rf $WORKSPACE/results || true
           if [ "{repo}" = "_" ]; then
             image={container}:{tag}
@@ -182,6 +198,7 @@
             --network={network} \
             $volumes \
             $env \
+            $published_ports \
 {% if publish_to_s3 == true %}
             -e S3_ENDPOINT_URL={{ s3_endpoint_url }} \
             -e S3_DST_URL={{ s3_dst_url }}/$BUILD_TAG/$JOB_NAME-$BUILD_ID \
@@ -363,6 +380,10 @@
 {% for key, value in (suite.docker_args |default (docker_args)).env.items() |list %}
       - {{ key }}=${{ key }}
 {% endfor %}
+    published_ports:
+{% for port in (suite.docker_args |default (docker_args)).published_ports %}
+      - {{ port }}
+{% endfor %}
     container: '{{ suite.container }}'
     test:
 {% for test in suite.tests %}
@@ -394,6 +415,11 @@
             for i in $(eval echo {env} | tr -d '[]' |sed "s/, / /g" ); \
               do env="-e $i $env"; done
           fi
+          published_ports=;
+          if [ "{published_ports}" != "None" ]; then
+            for i in $(echo {published_ports} | tr -d '[]' |sed "s/, / /g" ); \
+              do published_ports="-p $i $published_ports"; done
+          fi
           [ ! -z "$WORKSPACE" ] && {{sudo1 }}rm -rf $WORKSPACE/results || true
           if [ "{repo}" = "_" ]; then
             image={container}:{tag}
@@ -405,6 +431,7 @@
           {{ sudo1 }}docker run --rm \
             $volumes \
             $env \
+            $published_ports \
             -e S3_ENDPOINT_URL={{ s3_endpoint_url }} \
             -e S3_DST_URL={{ s3_dst_url }} \
             -e HTTP_DST_URL={{ http_dst_url }} \
@@ -456,6 +483,7 @@
           <<: *{{ project }}-containers
           volumes: '{volumes}'
           env: '{env}'
+          published_ports: '{published_ports}'
 
 - project:
     name: '{{ project }}-{tag}-zip'
@@ -475,6 +503,10 @@
     env:
 {% for key, value in ((suites | selectattr('repo', 'undefined') |first).docker_args |default (docker_args)).env.items() |list %}
       - {{ key }}=${{ key }}
+{% endfor %}
+    published_ports:
+{% for port in ((suites | selectattr('repo', 'undefined') |first).docker_args |default(docker_args)).published_ports %}
+      - {{ port }}
 {% endfor %}
     container: '{{ (suites | selectattr('repo', 'undefined') |first).container }}'
     jobs:


### PR DESCRIPTION
the  publish_ports parameter allows a container to run in server mode with its own tcp ports which can be mapped to the same or to different host ports as per Docker documentation https://docs.docker.com/config/containers/container-networking/ 

this change adds the publish_ports parameter in the jenkins-jobs Jinja2 template run.yaml.j2 under the docker_args directive. 
Then publish_ports parameter is a list of strings which has to be added to the site.yml even if not in use, using the [] notation (like volumes parameter)

