### PR TITLE
Some improvement and fixes

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -2,6 +2,7 @@
 # general
 prefix: /data
 tmp_dir: /tmp
+become_tasks: true
 ipaddress: "{{ ansible_default_ipv4.address }}"
 external_ipaddress: "{{ ipaddress }}"
 project: xtesting

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -77,6 +77,7 @@ jenkins_agent_docker_image: opnfv/xtesting-jenkins-agent
 jenkins_agent_docker_tag: 3.36-buster
 jenkins_agent_auto_docker_image: opnfv/xtesting-jenkins-agent-auto
 jenkins_agent_auto_docker_tag: 3.36-buster
+jenkins_agent_auto_container_name: "jenkins-agent"
 gitlab_docker_image: gitlab/gitlab-ce
 gitlab_docker_tag: 13.12.3-ce.0
 nexus_docker_image: sonatype/nexus3

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -214,6 +214,7 @@ testapi_deploy: true
 testapi_configure: '{{ testapi_deploy }}'
 testapi_port: 8000
 testapi_url: http://{{ ipaddress }}:{{ testapi_port }}/api/v1
+testapi_deploy_url: "{{ testapi_url }}"
 testapi_ext_url: http://{{ external_ipaddress }}:{{ testapi_port }}/api/v1
 testapi_base_url: http://{{ external_ipaddress }}:{{ testapi_port }}
 testapi_wait: 30

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -71,7 +71,7 @@
   delay: 5
 - name: Waiting TestAPI
   uri:
-    url: "{{ testapi_url }}/results"
+    url: "{{ testapi_deploy_url }}/results"
     method: GET
   register: _result
   until: _result.status == 200

--- a/tasks/cachet.yml
+++ b/tasks/cachet.yml
@@ -22,6 +22,8 @@
     - Waiting Cachet
   when:
     - cachet_deploy
+    - become_tasks or ansible_connection is not defined
+
 - name: Flushing handlers
   meta: flush_handlers
 - name: Checking if settings exist
@@ -167,6 +169,7 @@
     mode: '0755'
   when:
     - cachet_deploy or cachet_configure
+    - become_tasks
 - name: Creating cachet-url-monitor.yml
   become: true
   template:
@@ -175,6 +178,7 @@
     mode: '0644'
   when:
     - cachet_deploy or cachet_configure
+    - become_tasks
 - name: Starting cachet-url-monitor
   become: "{{ ansible_connection is defined }}"
   community.docker.docker_container:
@@ -190,3 +194,4 @@
     container_default_behavior: no_defaults
   when:
     - cachet_deploy or cachet_configure
+    - become_tasks or ansible_connection is not defined

--- a/tasks/debian.yml
+++ b/tasks/debian.yml
@@ -10,6 +10,7 @@
   changed_when: true
   when:
     - ansible_python.version.major==2
+    - become_tasks
 - name: Installing python3-apt
   become: true
   shell:
@@ -21,6 +22,7 @@
   changed_when: true
   when:
     - ansible_python.version.major==3
+    - become_tasks
 - name: Installing python-pip
   become: true
   apt:
@@ -33,6 +35,7 @@
   when:
     - not lookup('env','VIRTUAL_ENV')
     - ansible_python.version.major==2
+    - become_tasks
 - name: Installing python3-pip
   become: true
   apt:
@@ -45,6 +48,7 @@
   when:
     - not lookup('env','VIRTUAL_ENV')
     - ansible_python.version.major==3
+    - become_tasks
 - name: Gathering the package facts
   package_facts:
     manager: auto
@@ -62,6 +66,7 @@
     - not (ansible_distribution == 'Debian' and
         ansible_distribution_major_version|int <= 9)
     - not 'docker-ce' in ansible_facts.packages
+    - become_tasks
 - name: Installing curl
   become: true
   apt:
@@ -78,6 +83,7 @@
     - not (ansible_distribution == 'Debian' and
         ansible_distribution_version == 'testing')
     - not 'docker-ce' in ansible_facts.packages
+    - become_tasks
 - name: Installing docker
   become: true
   shell: curl -sSL https://get.docker.com | sh
@@ -88,6 +94,7 @@
     - not (ansible_distribution == 'Debian' and
         ansible_distribution_version == 'testing')
     - not 'docker-ce' in ansible_facts.packages
+    - become_tasks
 - name: Installing python-docker
   become: true
   apt:
@@ -99,6 +106,7 @@
   until: apt_res is success
   when:
     - ansible_python.version.major==2
+    - become_tasks
 - name: Installing python3-docker
   become: true
   apt:
@@ -110,6 +118,7 @@
   until: apt_res is success
   when:
     - ansible_python.version.major==3
+    - become_tasks
 - name: Installing python-pbr, python-fasteners, python-multi-key-dict,
     python-stevedore, python-yaml and python-jinja2
   become: true
@@ -129,6 +138,7 @@
   when:
     - ansible_python.version.major==2
     - jenkins_deploy or jenkins_configure
+    - become_tasks
 - name: Installing python3-importlib-metadata, python3-pbr, python3-fasteners,
     python3-multi-key-dict, python3-stevedore and python3-yaml
   become: true
@@ -148,6 +158,7 @@
   when:
     - ansible_python.version.major==3
     - jenkins_deploy or jenkins_configure
+    - become_tasks
 - name: Installing python-jenkins and jenkins-job-builder via pip
   become: "{{ not lookup('env','VIRTUAL_ENV') }}"
   pip:
@@ -157,6 +168,7 @@
     extra_args: --no-deps
   when:
     - jenkins_deploy or jenkins_configure
+    - become_tasks or lookup('env','VIRTUAL_ENV')
 - name: Installing python-jmespath
   become: true
   apt:
@@ -169,6 +181,7 @@
   when:
     - gitlab_deploy or gitlab_configure
     - ansible_python.version.major==2
+    - become_tasks
 - name: Installing python3-jmespath
   become: true
   apt:
@@ -181,6 +194,7 @@
   when:
     - gitlab_deploy or gitlab_configure
     - ansible_python.version.major==3
+    - become_tasks
 - name: Installing git
   become: true
   apt:
@@ -192,6 +206,7 @@
   until: apt_res is success
   when:
     - gitlab_create_jobs
+    - become_tasks
 - name: Installing python-psycopg2
   become: true
   apt:
@@ -204,6 +219,7 @@
   when:
     - postgres_deploy or cachet_configure
     - ansible_python.version.major==2
+    - become_tasks
 - name: Installing python3-psycopg2
   become: true
   apt:
@@ -216,6 +232,7 @@
   when:
     - postgres_deploy or cachet_configure
     - ansible_python.version.major==3
+    - become_tasks
 - name: Installing python-dateutil
   become: true
   apt:
@@ -231,6 +248,7 @@
     - ansible_python.version.major==2
     - ansible_distribution == 'Debian' and
         ansible_distribution_major_version|int <= 9
+    - become_tasks
 - name: Installing python3-dateutil
   become: true
   apt:
@@ -246,6 +264,7 @@
     - ansible_python.version.major==3
     - ansible_distribution == 'Debian' and
         ansible_distribution_major_version|int <= 9
+    - become_tasks
 - name: Installing pytz, msgpack and influxdb via pip
   become: "{{ not lookup('env','VIRTUAL_ENV') }}"
   pip:
@@ -258,6 +277,7 @@
     - influxdb_deploy
     - ansible_distribution == 'Debian' and
         ansible_distribution_major_version|int <= 9
+    - become_tasks or lookup('env','VIRTUAL_ENV')
 - name: Installing python-influxdb
   become: true
   apt:
@@ -273,6 +293,7 @@
     - ansible_python.version.major==2
     - not (ansible_distribution == 'Debian' and
         ansible_distribution_major_version|int <= 9)
+    - become_tasks
 - name: Installing python3-influxdb
   become: true
   apt:
@@ -287,6 +308,7 @@
     - ansible_python.version.major==3
     - not (ansible_distribution == 'Debian' and
         ansible_distribution_major_version|int <= 9)
+    - become_tasks
 - name: Installing python-dateutil
   become: true
   apt:
@@ -304,6 +326,7 @@
         ansible_distribution_major_version|int >= 10)
     - not (ansible_distribution == 'Ubuntu' and
         ansible_distribution_major_version|int > 20)
+    - become_tasks
 - name: Installing python3-dateutil
   become: true
   apt:
@@ -320,6 +343,7 @@
         ansible_distribution_major_version|int >= 10)
     - not (ansible_distribution == 'Ubuntu' and
         ansible_distribution_major_version|int > 20)
+    - become_tasks
 - name: Installing kubernetes via pip
   become: "{{ not lookup('env','VIRTUAL_ENV') }}"
   pip:
@@ -332,6 +356,7 @@
         ansible_distribution_major_version|int >= 10)
     - not (ansible_distribution == 'Ubuntu' and
         ansible_distribution_major_version|int > 20)
+    - become_tasks or lookup('env','VIRTUAL_ENV')
 - name: Installing python-kubernetes
   become: true
   apt:
@@ -349,6 +374,7 @@
         ansible_distribution_major_version|int <= 9)
     - not (ansible_distribution == 'Ubuntu' and
         ansible_distribution_major_version|int <= 18)
+    - become_tasks
 - name: Installing python3-kubernetes
   become: true
   apt:
@@ -366,6 +392,7 @@
         ansible_distribution_major_version|int <= 9)
     - not (ansible_distribution == 'Ubuntu' and
         ansible_distribution_major_version|int <= 20)
+    - become_tasks
 - name: Installing python-certifi, python-cachetools, python-oauthlib and
     python-requests-oauthlib
   become: true
@@ -383,6 +410,7 @@
   when:
     - use_kubernetes
     - ansible_python.version.major==2
+    - become_tasks
 - name: Installing python3-certifi, python3-cachetools, python3-oauthlib and
     python3-requests-oauthlib
   become: true
@@ -400,6 +428,7 @@
   when:
     - use_kubernetes
     - ansible_python.version.major==3
+    - become_tasks
 - name: Installing google.auth via pip
   become: "{{ not lookup('env','VIRTUAL_ENV') }}"
   pip:
@@ -411,6 +440,7 @@
     - ansible_python.version.major==2
     - ansible_distribution == 'Debian' and
         ansible_distribution_major_version|int <= 9
+    - become_tasks or lookup('env','VIRTUAL_ENV')
 - name: Installing python-google-auth
   become: true
   apt:
@@ -426,6 +456,7 @@
     - ansible_python.version.major==2
     - not (ansible_distribution == 'Debian' and
         ansible_distribution_major_version|int <= 9)
+    - become_tasks
 - name: Installing python3-google-auth
   become: true
   apt:
@@ -441,6 +472,7 @@
     - ansible_python.version.major==3
     - not (ansible_distribution == 'Debian' and
         ansible_distribution_major_version|int <= 9)
+    - become_tasks
 - name: Installing pyhelm and openshift via pip
   become: "{{ not lookup('env','VIRTUAL_ENV') }}"
   pip:
@@ -450,3 +482,4 @@
     extra_args: --no-deps
   when:
     - use_kubernetes
+    - become_tasks or lookup('env','VIRTUAL_ENV')

--- a/tasks/docker.yml
+++ b/tasks/docker.yml
@@ -5,6 +5,8 @@
     name: docker
     daemon_reload: true
     state: started
+  when:
+    - become_tasks
 - name: Adding ansible_user to docker group
   become: true
   user:
@@ -12,6 +14,8 @@
     groups:
       - docker
     append: true
+  when:
+    - become_tasks
 - name: Resetting connection
   meta: reset_connection
 - name: Creating /etc/systemd/system/docker.service.d
@@ -21,6 +25,7 @@
     state: directory
     mode: '0755'
   when:
+    - become_tasks
     - "'http_proxy' in ansible_env or 'https_proxy' in ansible_env"
 - name: Creating /etc/systemd/system/docker.service.d/http-proxy.conf
   become: true
@@ -32,6 +37,7 @@
   notify:
     - Restarting Docker
   when:
+    - become_tasks
     - "'http_proxy' in ansible_env or 'https_proxy' in ansible_env"
 - name: Creating /etc/docker/daemon.json
   become: true
@@ -43,6 +49,7 @@
   notify:
     - Restarting Docker
   when:
+    - become_tasks
     - registry_deploy
 - name: Flushing handlers
   meta: flush_handlers

--- a/tasks/elasticsearch.yml
+++ b/tasks/elasticsearch.yml
@@ -8,6 +8,7 @@
   when:
     - elasticsearch_deploy
     - not use_kubernetes
+    - become_tasks
 - name: Starting Elasticsearch
   become: "{{ ansible_connection is defined }}"
   community.docker.docker_container:
@@ -28,6 +29,7 @@
   when:
     - elasticsearch_deploy
     - not use_kubernetes
+    - become_tasks or ansible_connection is not defined
 - name: Adding Elasticsearch chart repository
   kubernetes.core.helm_repository:
     name: elastic

--- a/tasks/fluentd.yml
+++ b/tasks/fluentd.yml
@@ -7,6 +7,7 @@
     mode: '0777'
   when:
     - fluentd_deploy
+    - become_tasks
 - name: Starting Fluentd
   become: "{{ ansible_connection is defined }}"
   community.docker.docker_container:
@@ -25,3 +26,4 @@
     - Waiting Fluentd
   when:
     - fluentd_deploy
+    - become_tasks or ansible_connection is not defined

--- a/tasks/gitea.yml
+++ b/tasks/gitea.yml
@@ -22,6 +22,7 @@
     - Waiting Gitea
   when:
     - gitea_deploy
+    - become_tasks or ansible_connection is not defined
 - name: Flushing handlers
   meta: flush_handlers
 - name: Checking if account was already created
@@ -45,6 +46,7 @@
   when:
     - gitea_deploy
     - http_response.status == 401
+    - become_tasks or ansible_connection is not defined
 - name: Checking if project was already created
   uri:
     url: '{{ gitea_url }}/api/v1/repos/xtesting/{{ project }}'

--- a/tasks/gitlab.yml
+++ b/tasks/gitlab.yml
@@ -7,6 +7,7 @@
     mode: '0755'
   when:
     - gitlab_deploy
+    - become_tasks
 - name: Creating {{ prefix }}/gitlab/config/gitlab.rb
   become: true
   template:
@@ -16,6 +17,7 @@
   when:
     - gitlab_deploy
     - not use_kubernetes
+    - become_tasks
 - name: Starting GitLab
   become: "{{ ansible_connection is defined }}"
   community.docker.docker_container:
@@ -37,6 +39,7 @@
   when:
     - gitlab_deploy
     - not use_kubernetes
+    - become_tasks or ansible_connection is not defined
 - name: Adding GitLab chart repository
   kubernetes.core.helm_repository:
     name: gitlab
@@ -171,6 +174,7 @@
   when:
     - gitlab_sharedrunner_deploy
     - not use_kubernetes
+    - become_tasks
 - name: Starting shared GitLab runner
   become: "{{ ansible_connection is defined }}"
   community.docker.docker_container:
@@ -186,6 +190,7 @@
   when:
     - gitlab_sharedrunner_deploy
     - not use_kubernetes
+    - become_tasks or ansible_connection is not defined
 - name: Check GitLab Runner
   become: "{{ ansible_connection is defined }}"
   raw: docker exec gitlab-runner gitlab-runner list 2>&1 |grep shared |wc -l
@@ -193,6 +198,7 @@
   when:
     - gitlab_sharedrunner_deploy
     - not use_kubernetes
+    - become_tasks or ansible_connection is not defined
 - name: Registering shared GitLab runner
   become: "{{ ansible_connection is defined }}"
   raw: |
@@ -208,6 +214,7 @@
     - gitlab_sharedrunner_deploy
     - not use_kubernetes
     - runner.stdout_lines.0 | int < 1
+    - become_tasks or ansible_connection is not defined
 - name: Setting concurrent in gitlab-{{ project }}-runner/config.toml
   become: true
   lineinfile:
@@ -218,6 +225,7 @@
   when:
     - gitlab_configure
     - gitlab_privaterunner_deploy
+    - become_tasks
 - name: Starting private GitLab runner
   become: "{{ ansible_connection is defined }}"
   community.docker.docker_container:
@@ -233,6 +241,7 @@
   when:
     - gitlab_configure
     - gitlab_privaterunner_deploy
+    - become_tasks or ansible_connection is not defined
 - name: Adding private GitLab runner to inventory
   add_host:
     name: gitlab-{{ project }}-runner
@@ -250,6 +259,7 @@
   when:
     - gitlab_configure
     - gitlab_privaterunner_deploy
+    - become_tasks or ansible_connection is not defined
 - name: Registering private GitLab runner
   become: "{{ ansible_connection is defined }}"
   raw: |
@@ -271,6 +281,7 @@
     - gitlab_configure
     - gitlab_privaterunner_deploy
     - runner.stdout_lines.0 | int < 1
+    - become_tasks or ansible_connection is not defined
 - name: Getting GitLab access token
   uri:
     url: '{{ gitlab_url }}/oauth/token'

--- a/tasks/grafana.yml
+++ b/tasks/grafana.yml
@@ -8,6 +8,7 @@
   when:
     - grafana_deploy
     - not use_kubernetes
+    - become_tasks
 - name: Starting Grafana
   become: "{{ ansible_connection is defined }}"
   community.docker.docker_container:
@@ -26,6 +27,7 @@
   when:
     - grafana_deploy
     - not use_kubernetes
+    - become_tasks or ansible_connection is not defined
 - name: Adding Grafana chart repository
   kubernetes.core.helm_repository:
     name: grafana

--- a/tasks/influxdb.yml
+++ b/tasks/influxdb.yml
@@ -20,6 +20,7 @@
   when:
     - influxdb_deploy
     - not use_kubernetes
+    - become_tasks or ansible_connection is not defined
 - name: Adding InfluxDB chart repository
   kubernetes.core.helm_repository:
     name: influxdata

--- a/tasks/jenkins.yml
+++ b/tasks/jenkins.yml
@@ -154,7 +154,7 @@
 - name: Starting Jenkins agent
   become: "{{ ansible_connection is defined }}"
   community.docker.docker_container:
-    name: jenkins-agent
+    name: '{{ jenkins_agent_auto_container_name }}'
     image: '{{ jenkins_agent_auto_docker_image }}:{{ jenkins_agent_auto_docker_tag }}'
     pull: '{{ docker_pull }}'
     recreate: '{{ docker_recreate }}'

--- a/tasks/jenkins.yml
+++ b/tasks/jenkins.yml
@@ -8,6 +8,7 @@
   when:
     - jenkins_deploy
     - not use_kubernetes
+    - become_tasks
 - name: Creating casc_configs/jenkins.yaml
   become: true
   template:
@@ -18,6 +19,7 @@
   when:
     - jenkins_deploy
     - not use_kubernetes
+    - become_tasks
 - name: Starting Jenkins
   become: "{{ ansible_connection is defined }}"
   community.docker.docker_container:
@@ -40,6 +42,7 @@
     - jenkins_deploy
     - jenkins_network_mode != 'host'
     - not use_kubernetes
+    - become_tasks or ansible_connection is not defined
 - name: Starting Jenkins
   become: "{{ ansible_connection is defined }}"
   community.docker.docker_container:
@@ -59,6 +62,7 @@
     - jenkins_deploy
     - jenkins_network_mode == 'host'
     - not use_kubernetes
+    - become_tasks or ansible_connection is not defined
 - name: Adding Jenkins chart repository
   kubernetes.core.helm_repository:
     name: jenkins
@@ -166,6 +170,7 @@
     container_default_behavior: no_defaults
   when:
     - jenkins_agent_deploy
+    - become_tasks or ansible_connection is not defined
 - name: Creating jenkins_jobs.ini
   template:
     src: jenkins_jobs.ini.j2

--- a/tasks/kibana.yml
+++ b/tasks/kibana.yml
@@ -17,6 +17,7 @@
   when:
     - kibana_deploy
     - not use_kubernetes
+    - become_tasks or ansible_connection is not defined
 - name: Adding Kibana chart repository
   kubernetes.core.helm_repository:
     name: elastic

--- a/tasks/kubernetes.yml
+++ b/tasks/kubernetes.yml
@@ -10,6 +10,7 @@
       - 304
   when:
     - kubernetes_deploy
+    - become_tasks
 - name: Checking if the cluster exists
   shell: kind get clusters |grep xtesting |wc -l
   register: cluster_exist
@@ -62,6 +63,7 @@
     mode: '0755'
   when:
     - use_kubernetes
+    - become_tasks
 - name: Getting latest Kubernetes release
   uri:
     url: https://storage.googleapis.com/kubernetes-release/release/stable.txt
@@ -81,6 +83,7 @@
       - 304
   when:
     - use_kubernetes
+    - become_tasks
 - name: Creating configmap
   kubernetes.core.k8s:
     name: xtesting

--- a/tasks/minio.yml
+++ b/tasks/minio.yml
@@ -20,6 +20,7 @@
   when:
     - minio_deploy
     - not use_kubernetes
+    - become_tasks or ansible_connection is not defined
 - name: Adding Minio chart repository
   kubernetes.core.helm_repository:
     name: minio
@@ -62,6 +63,7 @@
     container_default_behavior: no_defaults
   when:
     - minio_deploy
+    - become_tasks or ansible_connection is not defined
 - name: Setting s3 endpoint url if Minio
   set_fact:
     s3_endpoint_url: 'http://{{ ipaddress }}:{{ minio_port }}'

--- a/tasks/mongodb.yml
+++ b/tasks/mongodb.yml
@@ -17,6 +17,7 @@
   when:
     - mongo_deploy
     - not use_kubernetes
+    - become_tasks or ansible_connection is not defined
 - name: Adding MongoDB chart repository
   kubernetes.core.helm_repository:
     name: bitnami

--- a/tasks/nexus.yml
+++ b/tasks/nexus.yml
@@ -7,6 +7,7 @@
     mode: '777'
   when:
     - nexus_deploy
+    - become_tasks
 - name: Starting Nexus
   become: "{{ ansible_connection is defined }}"
   community.docker.docker_container:
@@ -24,5 +25,6 @@
     - Waiting Nexus
   when:
     - nexus_deploy
+    - become_tasks or ansible_connection is not defined
 - name: Flushing handlers
   meta: flush_handlers

--- a/tasks/postgresql.yml
+++ b/tasks/postgresql.yml
@@ -21,6 +21,7 @@
   when:
     - postgres_deploy
     - not use_kubernetes
+    - become_tasks or ansible_connection is not defined
 - name: Adding PostgreSQL chart repository
   kubernetes.core.helm_repository:
     name: bitnami

--- a/tasks/radosgw.yml
+++ b/tasks/radosgw.yml
@@ -23,6 +23,7 @@
     container_default_behavior: no_defaults
   when:
     - radosgw_deploy
+    - become_tasks or ansible_connection is not defined
 - name: Waiting RadosGW
   pause:
     seconds: '{{ radosgw_wait }}'
@@ -47,21 +48,25 @@
   raw: docker cp {{ tmp_dir }}/cors.xml radosgw:cors.xml
   when:
     - radosgw_deploy
+    - become_tasks or ansible_connection is not defined
 - name: Copying policy.json in radosgw
   become: "{{ ansible_connection is defined }}"
   raw: docker cp {{ tmp_dir }}/policy.json radosgw:policy.json
   when:
     - radosgw_deploy
+    - become_tasks or ansible_connection is not defined
 - name: Applying cors.xml in radosgw
   become: "{{ ansible_connection is defined }}"
   raw: docker exec radosgw s3cmd setcors cors.xml s3://{{ bucket }}
   when:
     - radosgw_deploy
+    - become_tasks or ansible_connection is not defined
 - name: Applying policy.json in radosgw
   become: "{{ ansible_connection is defined }}"
   raw: docker exec radosgw s3cmd setpolicy policy.json s3://{{ bucket }}
   when:
     - radosgw_deploy
+    - become_tasks or ansible_connection is not defined
 - name: Setting s3 endpoint url if RagosGW
   set_fact:
     s3_endpoint_url: 'http://{{ ipaddress }}:{{ radosgw_port }}'

--- a/tasks/redhat.yml
+++ b/tasks/redhat.yml
@@ -18,6 +18,7 @@
     warn: false  # the yum module depends on python-dnf
   when:
     - ansible_python.version.major==2
+    - become_tasks
 - name: Installing python3-dnf
   become: true
   shell:
@@ -25,6 +26,7 @@
     warn: false  # the yum module depends on python-dnf
   when:
     - ansible_python.version.major==3
+    - become_tasks
 - name: Enabling EPEL release
   become: true
   yum:
@@ -33,6 +35,7 @@
   when:
     - not (ansible_distribution == "RedHat" and
         ansible_distribution_major_version | int <= 7)
+    - become_tasks
 - name: Enabling EPEL release
   become: true
   yum:
@@ -42,6 +45,7 @@
   when:
     - ansible_distribution == "RedHat"
     - ansible_distribution_major_version | int <= 7
+    - become_tasks
 - name: Installing python-pip
   become: true
   yum:
@@ -49,6 +53,7 @@
     update_cache: true
   when:
     - ansible_python.version.major==2
+    - become_tasks
 - name: Installing python3-pip
   become: true
   yum:
@@ -56,6 +61,7 @@
     update_cache: true
   when:
     - ansible_python.version.major==3
+    - become_tasks
 - name: Populating service ansible_facts
   service_facts:
 - name: Disabling firewalld
@@ -63,7 +69,9 @@
   systemd:
     name: firewalld
     state: stopped
-  when: ansible_facts.services['firewalld'] is defined
+  when:
+    - ansible_facts.services['firewalld'] is defined
+    - become_tasks
 - name: Installing iptables
   become: true
   yum:
@@ -71,6 +79,7 @@
     update_cache: true
   when:
     - ansible_distribution_major_version | int >= 8
+    - become_tasks
 - name: Adding Docker CE repository
   become: true
   changed_when: true
@@ -80,6 +89,7 @@
   when:
     - not (ansible_distribution == "RedHat" and
         ansible_distribution_major_version | int == 7)
+    - become_tasks
 - name: Installing docker-ce
   become: true
   yum:
@@ -88,6 +98,7 @@
   when:
     - not (ansible_distribution == "RedHat" and
         ansible_distribution_major_version | int == 7)
+    - become_tasks
 - name: Installing docker
   become: true
   yum:
@@ -97,11 +108,14 @@
   when:
     - ansible_distribution == "RedHat"
     - ansible_distribution_major_version | int == 7
+    - become_tasks
 - name: Changing state of selinux
   become: true
   ansible.posix.selinux:
     policy: targeted
     state: permissive
+  when:
+    - become_tasks
 - name: Installing python-websocket-client and python-requests
   become: true
   yum:
@@ -112,6 +126,7 @@
   when:
     - ansible_python.version.major==2
     - ansible_distribution_major_version | int == 7
+    - become_tasks
 - name: Installing python3-websocket-client
   become: true
   yum:
@@ -120,11 +135,14 @@
   when:
     - ansible_python.version.major==3
     - ansible_distribution_major_version | int >= 8
+    - become_tasks
 - name: Installing docker via pip
   become: "{{ not lookup('env','VIRTUAL_ENV') }}"
   pip:
     name: docker<=4.4.4
     extra_args: --no-deps
+  when:
+    - become_tasks or lookup('env','VIRTUAL_ENV')
 - name: Installing python-pbr, python-fasteners and python2-multi_key_dict
   become: true
   yum:
@@ -137,6 +155,7 @@
     - ansible_python.version.major==2
     - jenkins_deploy or jenkins_configure
     - ansible_distribution_major_version | int <= 7
+    - become_tasks
 - name: Installing python-jenkins via pip
   become: "{{ not lookup('env','VIRTUAL_ENV') }}"
   pip:
@@ -145,6 +164,7 @@
   when:
     - jenkins_deploy or jenkins_configure
     - ansible_distribution_major_version | int <= 7
+    - become_tasks or lookup('env','VIRTUAL_ENV')
 - name: Installing python3-importlib-metadata, python3-pbr, python3-jenkins and
     python3-fasteners
   become: true
@@ -159,6 +179,7 @@
     - ansible_python.version.major==3
     - jenkins_deploy or jenkins_configure
     - ansible_distribution_major_version | int >= 8
+    - become_tasks
 - name: Installing stevedore via pip
   become: "{{ not lookup('env','VIRTUAL_ENV') }}"
   pip:
@@ -166,6 +187,7 @@
     extra_args: --no-deps
   when:
     - jenkins_deploy or jenkins_configure
+    - become_tasks or lookup('env','VIRTUAL_ENV')
 - name: Installing six via pip
   become: "{{ not lookup('env','VIRTUAL_ENV') }}"
   pip:
@@ -174,6 +196,7 @@
   when:
     - jenkins_deploy or jenkins_configure
     - ansible_distribution_major_version | int <= 7
+    - become_tasks or lookup('env','VIRTUAL_ENV')
 - name: Installing jenkins-job-builder via pip
   become: "{{ not lookup('env','VIRTUAL_ENV') }}"
   pip:
@@ -181,6 +204,7 @@
     extra_args: --no-deps
   when:
     - jenkins_deploy or jenkins_configure
+    - become_tasks or lookup('env','VIRTUAL_ENV')
 - name: Installing python-jmespath
   become: true
   yum:
@@ -189,6 +213,7 @@
   when:
     - gitlab_deploy or gitlab_configure
     - ansible_python.version.major==2
+    - become_tasks
 - name: Installing python3-jmespath
   become: true
   yum:
@@ -197,6 +222,7 @@
   when:
     - gitlab_deploy or gitlab_configure
     - ansible_python.version.major==3
+    - become_tasks
 - name: Installing git
   become: true
   yum:
@@ -204,6 +230,7 @@
     update_cache: true
   when:
     - gitlab_create_jobs
+    - become_tasks
 - name: Installing python-psycopg2
   become: true
   yum:
@@ -212,6 +239,7 @@
   when:
     - postgres_deploy or cachet_configure
     - ansible_python.version.major==2
+    - become_tasks
 - name: Installing python3-psycopg2
   become: true
   yum:
@@ -220,6 +248,7 @@
   when:
     - postgres_deploy or cachet_configure
     - ansible_python.version.major==3
+    - become_tasks
 - name: Installing pytz and python-dateutil
   become: true
   yum:
@@ -230,6 +259,7 @@
   when:
     - influxdb_deploy
     - ansible_python.version.major==2
+    - become_tasks
 - name: Installing python3-msgpack
   become: true
   yum:
@@ -238,6 +268,7 @@
   when:
     - influxdb_deploy
     - ansible_python.version.major==3
+    - become_tasks
 - name: Installing influxdb<=4.0.0 via pip
   become: "{{ not lookup('env','VIRTUAL_ENV') }}"
   pip:
@@ -246,6 +277,7 @@
   when:
     - influxdb_deploy
     - ansible_distribution_major_version | int <= 7
+    - become_tasks or lookup('env','VIRTUAL_ENV')
 - name: Installing influxdb<=5.3.1 via pip
   become: "{{ not lookup('env','VIRTUAL_ENV') }}"
   pip:
@@ -254,6 +286,7 @@
   when:
     - influxdb_deploy
     - ansible_distribution_major_version | int >= 8
+    - become_tasks or lookup('env','VIRTUAL_ENV')
 - name: Installing python-certifi, python-cachetools, python-oauthlib,
     python-requests-oauthlib and python2-kubernetes
   become: true
@@ -269,6 +302,7 @@
   when:
     - use_kubernetes
     - ansible_python.version.major==2
+    - become_tasks
 - name: Installing python3-certifi, python3-cachetools, python3-oauthlib,
     python3-requests-oauthlib and python3-kubernetes
   become: true
@@ -284,6 +318,7 @@
   when:
     - use_kubernetes
     - ansible_python.version.major==3
+    - become_tasks
 - name: Installing setuptools via pip
   become: "{{ not lookup('env','VIRTUAL_ENV') }}"
   pip:
@@ -293,6 +328,7 @@
   when:
     - use_kubernetes
     - ansible_distribution_major_version | int <= 7
+    - become_tasks or lookup('env','VIRTUAL_ENV')
 - name: Installing pyhelm and openshift via pip
   become: "{{ not lookup('env','VIRTUAL_ENV') }}"
   pip:
@@ -302,3 +338,4 @@
     extra_args: --no-deps
   when:
     - use_kubernetes
+    - become_tasks or lookup('env','VIRTUAL_ENV')

--- a/tasks/registry.yml
+++ b/tasks/registry.yml
@@ -14,3 +14,4 @@
     container_default_behavior: no_defaults
   when:
     - registry_deploy
+    - become_tasks or ansible_connection is not defined

--- a/tasks/testapi.yml
+++ b/tasks/testapi.yml
@@ -23,7 +23,7 @@
   meta: flush_handlers
 - name: Checking if pod is already registered
   uri:
-    url: '{{ testapi_url }}/pods/{{ project }}'
+    url: '{{ testapi_deploy_url }}/pods/{{ project }}'
     status_code:
       - 200
       - 404
@@ -32,7 +32,7 @@
     - testapi_deploy or testapi_configure
 - name: Registering the pod
   uri:
-    url: '{{ testapi_url }}/pods'
+    url: '{{ testapi_deploy_url }}/pods'
     method: POST
     body: {"name":"{{ project }}"}
     status_code: 200
@@ -42,7 +42,7 @@
     - http_response.status != 200
 - name: Checking if project is already registered
   uri:
-    url: '{{ testapi_url }}/projects/{{ item.db_project|default(db_project) }}'
+    url: '{{ testapi_deploy_url }}/projects/{{ item.db_project|default(db_project) }}'
     status_code:
       - 200
       - 404
@@ -52,7 +52,7 @@
     - testapi_deploy or testapi_configure
 - name: Registering the project
   uri:
-    url: '{{ testapi_url }}/projects'
+    url: '{{ testapi_deploy_url }}/projects'
     method: POST
     body: {"name":"{{ item.item.db_project | default(db_project) }}"}
     status_code:
@@ -66,7 +66,7 @@
     - item.status != 200
 - name: Checking if testcase is already registered
   uri:
-    url: "{{ testapi_url }}/projects/{{
+    url: "{{ testapi_deploy_url }}/projects/{{
       item.0.db_project |default(db_project) }}/cases/{{ item.1 }}"
     status_code:
       - 200
@@ -79,7 +79,7 @@
     - testapi_deploy or testapi_configure
 - name: Registering the testcases
   uri:
-    url: "{{ testapi_url }}/projects/{{
+    url: "{{ testapi_deploy_url }}/projects/{{
       item.item.0.db_project |default(db_project) }}/cases"
     method: POST
     body: {"name":"{{ item.item.1 }}"}

--- a/tasks/testapi.yml
+++ b/tasks/testapi.yml
@@ -18,6 +18,7 @@
     - Waiting TestAPI
   when:
     - testapi_deploy
+    - become_tasks or ansible_connection is not defined
 - name: Flushing handlers
   meta: flush_handlers
 - name: Checking if pod is already registered

--- a/tasks/testapi.yml
+++ b/tasks/testapi.yml
@@ -23,23 +23,27 @@
   meta: flush_handlers
 - name: Checking if pod is already registered
   uri:
-    url: '{{ testapi_deploy_url }}/pods/{{ project }}'
+    url: '{{ testapi_deploy_url }}/pods/{{ (item.values() | list).0.slave | default(node_name) }}'
     status_code:
       - 200
       - 404
   register: http_response
+  loop: "{{ docker_tags }}"
   when:
     - testapi_deploy or testapi_configure
 - name: Registering the pod
   uri:
     url: '{{ testapi_deploy_url }}/pods'
     method: POST
-    body: {"name":"{{ project }}"}
+    body: {"name":"{{ (item.values() | list).0.slave | default(node_name) }}"}
     status_code: 200
     body_format: json
+  loop: "{{ docker_tags }}"
+  loop_control:
+    index_var: loop_idx
   when:
     - testapi_deploy or testapi_configure
-    - http_response.status != 200
+    - http_response.results[loop_idx].status != 200
 - name: Checking if project is already registered
   uri:
     url: '{{ testapi_deploy_url }}/projects/{{ item.db_project|default(db_project) }}'

--- a/tasks/vault.yml
+++ b/tasks/vault.yml
@@ -15,6 +15,7 @@
     container_default_behavior: no_defaults
   when:
     - vault_deploy
+    - become_tasks or ansible_connection is not defined
 - name: Waiting Vault
   pause:
     seconds: '{{ vault_wait }}'


### PR DESCRIPTION
This pull request is made of 4 commits, each addressing a specific additional feature or bug fix.

**1. Added possibility to skip tasks that require privilege escalation (become)** [8c322e14785d2ff0d36089942f8951526a50adc9]
We might want to run the Ansible playbook without executing any of the tasks that require privilege escalation. For example, if we don't need to deploy any component and only want to push the new tests pipeline into the scheduler and TestAPI.

This change adds a new boolean variable `become_tasks` which defaults to `true`. It is used as a condition for all tasks that required privilege escalation. For tasks where privilege escalation depended on a condition (e.g. `become: "{{ ansible_connection is defined }}"`), the skipping condition in `when` includes the "or" and negation of this condition so that the task is not skipped when privilege escalation was not needed. In that example, the condition will be `become_tasks or ansible_connection is not defined`.


**2. Added possibility to change Jenkins agent's name (w/o K8s)** [d81816f8f334b3e109e6fce10e1c23e7125a3238]
This is necessary if we want to use the Ansible role to deploy multiple Jenkins agents on the same machine. It was not possible because the container name was hardcoded and always the same: "jenkins-agent".
A new variable is added: `jenkins_agent_auto_container_name`, which defaults to `jenkins-agent`. It is used in the "Starting Jenkins agent" task, when `kubernetes_deploy` is `false`.


**3. Added disjoint URLs for TestAPI deploy and test execution vars** [641edf3eb951e0fafd174276bef10135206b6616]
The same variable `testapi_url` was used in two different contexts:
* when registering the pod/project/testcases in TestAPI (job deployment phase)
* by the test container following test execution to push test results to TestAPI (passed as environment variables)

A new variable is added: `testapi_deploy_url`, whch defaults to the value of `testapi_url`.

It is now possible to use a different endpoint for these two actions, which is useful because if the runner is not located on the machine where the playbook is executed then it may not be able to reach TestAPI via the same URL.


**4. Fixed wrong TestAPI pod name registration** [90283c0b06534aaf4f1f3bd4a13a5fb1132cc02d]
There was a discrepancy between the pod name registration and the pod_name used by the container when trying to push results to TestAPI (see https://github.com/opnfv/functest-xtesting/blob/861f79d46397d8bbc5b55b95bc4ca2ac0fb1f247/xtesting/core/testcase.py#L222)

The registration tasks used the value of the `project` variable from the Ansible playbook, whereas the test container used the `NODE_NAME` environment variable (defined in `run.yaml.j2`, either equal to the slave name or to `node_name` if `use_slave` is `false`).

The change proposes to register the pods based on the values of the `slave` variables in the Docker tags if defined (or `node_name` if not defined). It adds a loop in the task and makes it possible to register multiple pods.
