### PR TITLE
Gitlab CI/CD settings configuration.

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -179,6 +179,8 @@ gitlab_privaterunner_image: alpine:latest
 gitlab_privaterunner_network_mode: bridge  # or host
 gitlab_ci_mode: "overwrite"  # or insert
 gitlab_use_chainedci: false
+gitlab_ci_variables: []
+purge_gitlab_ci_variables: false
 
 # s3
 publish_to_s3: true

--- a/tasks/debian.yml
+++ b/tasks/debian.yml
@@ -181,6 +181,12 @@
   when:
     - gitlab_deploy or gitlab_configure
     - ansible_python.version.major==3
+- name: Installing python-gitlab via pip
+  become: "{{ not lookup('env','VIRTUAL_ENV') }}"
+  pip:
+    name: python-gitlab
+  when:
+    - gitlab_deploy or gitlab_configure
 - name: Installing git
   become: true
   apt:

--- a/tasks/gitlab.yml
+++ b/tasks/gitlab.yml
@@ -525,3 +525,12 @@
   when:
     - gitlab_configure
     - gitlab_create_jobs
+- name: Set or update CI/CD variables
+  community.general.gitlab_project_variable:
+    api_url: '{{ gitlab_url }}'
+    api_oauth_token: '{{ oauth.json.access_token }}'
+    project: 'xtesting/{{ project }}'
+    purge: '{{ purge_gitlab_ci_variables }}'
+    variables: '{{ gitlab_ci_variables }}'
+  when:
+    -  gitlab_configure

--- a/tasks/redhat.yml
+++ b/tasks/redhat.yml
@@ -197,6 +197,12 @@
   when:
     - gitlab_deploy or gitlab_configure
     - ansible_python.version.major==3
+- name: Installing python-gitlab via pip
+  become: "{{ not lookup('env','VIRTUAL_ENV') }}"
+  pip:
+    name: python-gitlab
+  when:
+    - gitlab_deploy or gitlab_configure
 - name: Installing git
   become: true
   yum:


### PR DESCRIPTION
Add the possibility to set variables for CI/CD on level project.

Variables can be configured through `gitlab_ci_variables` parameter.  
Example:  
```
gitlab_ci_variables:
    - name: SERVER_NAME
       value: myServer
    - name: USERNAME
       value: user1
```

By default, untouched variable will be kept. To remove them, set `purge_gitlab_ci_variables` parameter to true