### PR TITLE
Add option to be able to disable Gitlab job scheduling

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -182,6 +182,7 @@ gitlab_wait: 300
 gitlab_commit_msg: Update .gitlab-ci.yml via XtestingCI
 gitlab_user_mail: "{{ user_mail }}"
 gitlab_clone_version: main
+gitlab_enable_scheduling: true
 gitlab_sharedrunner_deploy: "{{ gitlab_deploy }}"
 gitlab_sharedrunner_concurrent: 10
 gitlab_privaterunner_deploy: false

--- a/tasks/gitlab.yml
+++ b/tasks/gitlab.yml
@@ -433,6 +433,7 @@
       - [description, '{{ project }}-daily']
       - [cron, "0 16 * * *"]
       - [ref, '{{ gitlab_clone_version }}']
+      - [active, '{{ gitlab_enable_scheduling }}']
     status_code:
       - 201
   when:


### PR DESCRIPTION
In some use cases, I need to disable Gitlab job scheduling which is enabled by default.
This pull request add the option "gitlab_enable_scheduling" to be able to disable it if necessary.